### PR TITLE
Bring a couple updates from upstream NitroSpoof

### DIFF
--- a/plugins/BetterNitroSpoof/build.gradle.kts
+++ b/plugins/BetterNitroSpoof/build.gradle.kts
@@ -1,5 +1,5 @@
 description = "(requires MoreHighlight to hide the hyperlink) Nitrospoof: Now with hyperlinked emojis like other spoofs."
-version = "1.0.10"
+version = "1.0.11"
 
 aliucord.changelog.set("""
   # 1.0.10

--- a/plugins/BetterNitroSpoof/build.gradle.kts
+++ b/plugins/BetterNitroSpoof/build.gradle.kts
@@ -2,17 +2,18 @@ description = "(requires MoreHighlight to hide the hyperlink) Nitrospoof: Now wi
 version = "1.0.11"
 
 aliucord.changelog.set("""
-  # 1.0.10
+  # 1.0.11
   * just modded the plugin so it hyperlinks emotes to work with other platforms.
   * now requires MoreHighlight so that the hyperlinks work
+  # 1.0.10
+  * Added the lossless quality argument to the emoji URL to combat Blur (by RGBCube)
+  * Added the emoji name argument to the URL to help Vencord properly display the emoji (by Delphox)
+  * Fix emojis breaking when the server boost runs out (by Delphox)
+  * Fix invalid emoji size breaking the final emoji URL (by RGBCube)
   # 1.0.9
   * Removed the troll and made NitroSpoof work again
   * Thanks to Lenk for helping me with the code
   * The /freenitro slash command was changed to /freenitroll (use the command if you are sure you want to allow it to delete NitroSpoof)
   * No the command is not malicious and I am specifically telling you it will only delete NitroSpoof.zip
   * Ven is still my beloved -Foxy
-  # 1.0.8
-  * Added a new command called freenitro which gives you real nitro for free
-  * "Improved" Code and stability of nitro spoof
-  * Ven my beloved
 """.trimIndent())

--- a/plugins/BetterNitroSpoof/src/main/kotlin/com/github/phob/BetterNitroSpoof.kt
+++ b/plugins/BetterNitroSpoof/src/main/kotlin/com/github/phob/BetterNitroSpoof.kt
@@ -52,8 +52,9 @@ class BetterNitroSpoof : Plugin() {
     private fun getChatReplacement(callFrame: XC_MethodHook.MethodHookParam) {
         val thisObject = callFrame.thisObject as ModelEmojiCustom
         val isUsable = thisObject.getCachedField<Boolean>("isUsable")
+        val available = thisObject.getCachedField<Boolean>("available")
 
-        if (isUsable) {
+        if (isUsable && available)  {
             callFrame.result = callFrame.result
             return
         }
@@ -67,7 +68,7 @@ class BetterNitroSpoof : Plugin() {
         finalUrl += idStr
         val emoteSize = settings.getString(EMOTE_SIZE_KEY, EMOTE_SIZE_DEFAULT).toIntOrNull()
 
-        finalUrl += (if (isAnimated) ".gif" else ".png") + "?quality=lossless"
+        finalUrl += (if (isAnimated) ".gif" else ".png") + "?quality=lossless&name=" + emoteName
 
         if (emoteSize != null) {
             finalUrl += "&size=${emoteSize}"


### PR DESCRIPTION
1. Add emote name to url, making the emoji name show correctly on Vencord when FakeNitro's Transform Emojis option is enabled.
2. Make NitroSpoof work on unavailable emojis when server nitro boost runs out.